### PR TITLE
Align version references with v3.1.8 corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# 🏠 Land Acquisition Pipeline v3.1.6
+# 🏠 Land Acquisition Pipeline v3.1.8
 
 **Status**: ✅ **PRODUCTION READY** - Enhanced funnel metrics with executive KPIs
-**Last Updated**: July 6, 2025
-**Version**: 3.1.6 (Enhanced Funnel Analytics + Business Intelligence + Modernized Interface)
+**Last Updated**: July 15, 2025
+**Version**: 3.1.8 (Metric alignment + Business Intelligence + Modernized Interface)
 
 ## 📋 **What This Does**
 
@@ -45,12 +45,13 @@ Single file: `[Campaign_Name]_Results.xlsx` with 10 enhanced sheets + PowerBI ex
 - **Campaign_Scorecard**: High-level executive summary
 - **🆕 PowerBI_Dataset.csv**: Business intelligence export for dashboards ✅ Working
 
-## 📊 **Current Status (v3.1.6)**
+## 📊 **Current Status (v3.1.8)**
 
-### 🆕 **New in v3.1.6**
-- **Modernized Campaign Launcher**: Completely rewritten interface (57% code reduction) with current v3.1.5 features
-- **Documentation Reconciliation**: All documents updated for version consistency and broken references fixed
-- **Streamlined User Experience**: Simplified workflow with clear status indicators and accurate output descriptions
+### 🆕 **New in v3.1.8**
+- **Direct Mail Metric Alignment**: `Direct_Mail_Final_Contacts` now counts ULTRA_HIGH, HIGH, and MEDIUM confidence addresses, matching the Final_Mailing_List and executive dashboard.
+- **Agency Metric Consistency**: `Agency_Final_Contacts` focuses on LOW confidence addresses for accurate totals and percentages.
+- **Dashboard Validation**: Pipeline outputs verified against `complete_robust_dashboard.py` to ensure Excel metrics and visualizations stay in sync.
+- **Modernized Campaign Launcher**: Interface updated with the latest version banner and feature list for clear operator messaging.
 
 ### **Recent Features (v3.1.5)**
 - **Enhanced `Final_Mailing_List` Structure**: Improved usability with `cf`, `Addresses_Per_Owner`, and `Address_Sequence` columns, sorted by owner

--- a/campaign_launcher.py
+++ b/campaign_launcher.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-Land Acquisition Campaign Launcher v3.1.6
+Land Acquisition Campaign Launcher v3.1.8
 Streamlined interface for renewable energy land acquisition campaigns
 Supports enhanced funnel analytics, address quality intelligence, and executive KPIs
 
-@version: 3.1.6 (Enhanced Funnel Analytics + Business Intelligence + Cost Tracking)
+@version: 3.1.8 (Metric alignment + Business Intelligence + Cost Tracking)
 @updated: July 2025
 """
 
@@ -16,7 +16,7 @@ from pathlib import Path
 
 class LandAcquisitionCampaignLauncher:
     def __init__(self):
-        self.version = "3.1.6"
+        self.version = "3.1.8"
         self.load_config()
         
     def load_config(self):
@@ -74,10 +74,11 @@ class LandAcquisitionCampaignLauncher:
         print(f"   • PowerBI Export: {'✅ ENABLED' if powerbi_export else '❌ DISABLED'}")
         print()
         
-        print("🆕 CURRENT FEATURES (v3.1.6):")
+        print("🆕 CURRENT FEATURES (v3.1.8):")
         print("   • Enhanced Final_Mailing_List with owner grouping and sequence numbers")
-        print("   • Refined address classification for better confidence levels") 
+        print("   • Refined address classification for better confidence levels")
         print("   • Business-friendly funnel metrics with executive KPIs")
+        print("   • Corrected Direct_Mail/Agency contact metrics aligned with dashboard outputs")
         print("   • Comprehensive metrics documentation and validation")
         print("   • Zero-touch processing identification (17.4% automation)")
         print("   • Integrated cost tracking with start/end balance prompts")

--- a/doc/version_alignment_audit_v3.1.8.md
+++ b/doc/version_alignment_audit_v3.1.8.md
@@ -1,0 +1,18 @@
+# Version Alignment Audit – v3.1.8
+
+## Feature Verification
+- **Direct mail metric logic** – `create_municipality_summary` now builds `direct_mail_df` by filtering `Address_Confidence` for `ULTRA_HIGH`, `HIGH`, and `MEDIUM`, so the `Direct_Mail_Final_Contacts` count is aligned with what the dashboard recomputes. (land_acquisition_pipeline.py, lines ~1214-1234)
+- **Agency metric correction** – the same function now restricts agency contacts to `Address_Confidence == 'LOW'`, fixing the previously inconsistent total when compared to the dashboard’s robust calculations. (land_acquisition_pipeline.py, lines ~1234-1238)
+- **Area aggregation** – both contact channels de-duplicate parcels before summing hectares, matching the executive dashboard’s methodology. (land_acquisition_pipeline.py, lines ~1239-1242)
+- **Dashboard baseline** – the authoritative visualization logic lives in `visualization_mission/SYNC/complete_robust_dashboard.py` (VERSION 3.3) and recomputes the same parcel counts directly from the Excel outputs, confirming the corrected methodology. (visualization_mission/SYNC/complete_robust_dashboard.py, lines ~26-116)
+
+## Version Reference Inventory
+- `land_acquisition_pipeline.py` previously identified itself as **v2.9.x** in the header, logging banner, CLI description, and cost summary output even though the implemented features were v3.1.7/v3.1.8. ✅ Updated to 3.1.8 across those touchpoints.
+- `campaign_launcher.py` exposed version **3.1.6** in the header, banner, and feature list. ✅ Updated to 3.1.8 with refreshed messaging.
+- `README.md` marketed the project as **v3.1.6** and its “New in” section stopped at that release. ✅ Updated to 3.1.8 with metric-alignment highlights.
+- `COMMIT_MESSAGE_v3.1.6.txt` documents the last reconciliation against v3.1.6 (left untouched for historical reference).
+
+## Cleanup Opportunities (Next Steps to Discuss)
+- Consolidate duplicate dashboard scripts scattered under `visualization_mission/` – the SYNC copy is the correct reference, so older variants in `data/` and `final script/` could be archived elsewhere.
+- Review the large `dev_tools/` directory; many helpers are historical and may no longer be required in the main repository.
+- Consider relocating campaign-specific outputs (e.g., `visualization_mission/outputs/`) into an archival bucket to keep the core pipeline workspace focused on production assets.

--- a/land_acquisition_pipeline.py
+++ b/land_acquisition_pipeline.py
@@ -3,7 +3,7 @@
 Enhanced Land Acquisition Pipeline with Geocoding Integration and Funnel Metrics
 Handles complete workflow from single input file to municipality-structured outputs
 ENHANCED: Automatic geocoding, PEC email retrieval, and comprehensive funnel tracking
-VERSION: 2.9.7 (with parcel ownership grouping analysis)
+VERSION: 3.1.8 (direct mail/agency metric alignment and dashboard-ready outputs)
 
 @author: Optimized for CP-Municipality land acquisition workflow with address enhancement
 """
@@ -1150,7 +1150,7 @@ The campaign "{campaign_name}" is complete. Results are in OneDrive and ready fo
 **Key Improvements in this Output:**
 
 - **Cleaner Contacts**: The `Validation_Ready.xlsx` file is now **de-duplicated**. You will only see each unique owner once per unique address, saving you time.
-- **Smarter Addresses (v2.9!)**: Each address now has a quality score (`Address_Confidence`) and a recommended `Routing_Channel` (DIRECT_MAIL or AGENCY) to minimize costs from returned mail.
+- **Smarter Addresses (v3.1!)**: Each address now has a quality score (`Address_Confidence`) and a recommended `Routing_Channel` (DIRECT_MAIL or AGENCY) to minimize costs from returned mail.
 - **SNC Addresses Update**: SNC addresses are now sent to DIRECT_MAIL as postal service knows these small streets well.
 {pec_summary}- **Smarter Summaries**: The `Municipality_Summary` sheet now contains powerful business intelligence metrics with complete funnel tracking.
 - **Funnel Visibility**: New sheets show how many parcels and hectares flow through each processing stage.
@@ -1314,7 +1314,7 @@ Best,
         self.logger.setLevel(logging.INFO)
         self.logger.addHandler(file_handler)
         self.logger.addHandler(console_handler)
-        self.logger.info("Enhanced Land Acquisition Pipeline v2.9 initialized")
+        self.logger.info("Enhanced Land Acquisition Pipeline v3.1.8 initialized")
     
     def setup_directories(self):
         """Create necessary directories"""
@@ -1375,7 +1375,7 @@ Best,
         print(f"📍 Total Parcels: {self.campaign_stats['total_parcels']}")
         print(f"🗺️  Address Enhancement: {'✅ ENABLED' if self.geocoding_enabled else '❌ DISABLED'}")
         print(f"📧 PEC Email Integration: {'✅ ENABLED' if self.pec_enabled else '❌ DISABLED'}")
-        print(f"📊 Funnel Tracking: ✅ ENABLED (v2.9)")
+        print(f"📊 Funnel Tracking: ✅ ENABLED (v3.1.8)")
         
         print("\n📋 CP Structure:")
         for cp, row in cp_summary.iterrows():
@@ -1588,7 +1588,7 @@ Best,
 
     def run_complete_campaign(self, input_file, campaign_name, start_balance=None):
         """v2.9.5: Main method to run the campaign, now aggregates all results into a single file."""
-        print(f"\n🚀 ENHANCED LAND ACQUISITION CAMPAIGN v2.9.5: {campaign_name}")
+        print(f"\n🚀 ENHANCED LAND ACQUISITION CAMPAIGN v3.1.8: {campaign_name}")
         if start_balance is None:
             start_balance = self.get_manual_balance_input("start")
         else:
@@ -1653,7 +1653,7 @@ Best,
             traceback.print_exc()
         self.copy_to_onedrive(campaign_name, campaign_dir)
         
-        print(f"\n✅ ENHANCED CAMPAIGN COMPLETED (v2.9.5)")
+        print(f"\n✅ ENHANCED CAMPAIGN COMPLETED (v3.1.8)")
 
     def create_enhanced_cost_summary(self, campaign_name, campaign_dir):
         """Create enhanced cost summary."""
@@ -1661,7 +1661,7 @@ Best,
         pec_section = f"PEC Integration Enabled: {'Yes' if self.pec_enabled else 'No'}\n"
 
         cost_summary = f"""
-ENHANCED LAND ACQUISITION CAMPAIGN COST SUMMARY v2.9
+ENHANCED LAND ACQUISITION CAMPAIGN COST SUMMARY v3.1.8
 Campaign: {campaign_name}
 Processing Date: {datetime.now().strftime('%Y-%m-%d %H:%M')}
 
@@ -1671,8 +1671,8 @@ End Balance: €{self.campaign_stats['end_balance']:.2f}
 Total Campaign Cost: €{self.campaign_stats['campaign_cost']:.2f}
 
 {geocoding_section}{pec_section}
-Funnel Tracking: Enabled (v2.9)
-SNC Routing: Direct Mail (v2.9)
+Funnel Tracking: Enabled (v3.1.8)
+SNC Routing: Direct Mail (v3.1.8)
 
 📊 PROCESSING STATS:
 Total API Calls: {self.campaign_stats['api_calls']}
@@ -2238,7 +2238,7 @@ Validation Ready Records: {self.campaign_stats['validation_ready_count']}
 
 if __name__ == "__main__":
     import argparse
-    parser = argparse.ArgumentParser(description='Enhanced Land Acquisition Pipeline v2.9')
+    parser = argparse.ArgumentParser(description='Enhanced Land Acquisition Pipeline v3.1.8')
     parser.add_argument('--config', required=True, help='Campaign configuration file')
     parser.add_argument('--start-balance', type=float, help='Starting API balance')
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- update the pipeline header, logging banner, runtime prints, and cost summary messaging to advertise v3.1.8 and the corrected direct-mail/agency metrics
- refresh the campaign launcher and README to present the project as v3.1.8 with highlights on the metric alignment and dashboard validation
- capture the verification work in a new `doc/version_alignment_audit_v3.1.8.md` so future clean-up tasks have a written audit trail

## Testing
- python -m compileall land_acquisition_pipeline.py campaign_launcher.py

------
https://chatgpt.com/codex/tasks/task_e_68d42e7d51c4832381da2338427fb0f3